### PR TITLE
Fix width on navigation elements

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -248,6 +248,6 @@ footer h3 {
 }
 @media only screen and (min-width: 62.5em) {
 		nav a.nav-link {
-			width: 24.7%;
+			width: 24.6%;
 		}
 }


### PR DESCRIPTION
It's a small change - and potentially a result of a Chrome quirk - but I figured it was better than leaving a weird issue like this lying around. A side-effect of the change is that the text is slightly smaller, but I think it looks better this way anyhow.

> Note: I think the best fix for this would be to __actually__ use [Foundation's Grid](http://foundation.zurb.com/sites/docs/v/5.5.3/components/grid.html), but as that is a larger change that would require actual work on my part, I figure this is the least of all evils.

Before:

![http://cl.ly/2n152m3o3s11](http://cl.ly/2n152m3o3s11/Image%202015-12-16%20at%2012.05.51%20AM.png)

After:

![http://cl.ly/1Q3K0z1j0V1m](http://cl.ly/1Q3K0z1j0V1m/Image%202015-12-16%20at%2012.06.35%20AM.png)
