### PR TITLE
Use correct url references to the fonts

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -2,22 +2,22 @@
 @font-face {
   font-family: 'Source Sans Pro';
   font-weight: 100;
-  src: url('.../fonts/SourceSansPro-Light.ttf');
+  src: url('../fonts/SourceSansPro-Light.ttf');
 }
 @font-face {
   font-family: 'Source Sans Pro';
   font-weight: normal;
-  src: url('.../fonts/SourceSansPro-Regular.ttf');
+  src: url('../fonts/SourceSansPro-Regular.ttf');
 }
 @font-face {
   font-family: 'Source Sans Pro';
   font-weight: bold;
-  src: url('.../fonts/SourceSansPro-Bold.ttf');
+  src: url('../fonts/SourceSansPro-Bold.ttf');
 }
 @font-face {
   font-family: 'Source Sans Pro';
   font-weight: 800;
-  src: url('.../fonts/SourceSansPro-Black.ttf');
+  src: url('../fonts/SourceSansPro-Black.ttf');
 }
 
 /* Global*/


### PR DESCRIPTION
A possible alternative to the fix I put in #3. I think the only reason it may have originally looked good on your computers is because you have the `Source Sans Pro` fonts installed locally. 

One of our frontend people looked at my original PR and told me I was lying, and thats how we figured out it was the font not resolving (he installs a billion fonts of course). I totally should have caught this when I opened up Webkit Inspector.

Here is what it probably looks like with the font loading (screenshot not from my computer, so it's totally possible that a different font is being loaded in it's place):

![http://cl.ly/2K3y2M0F0E0t](http://cl.ly/2K3y2M0F0E0t/Image%202015-12-16%20at%2012.23.49%20AM.png)
